### PR TITLE
[fix] maven compiles with 1.3 compatibility

### DIFF
--- a/addon-selfadministration-plugin/pom.xml
+++ b/addon-selfadministration-plugin/pom.xml
@@ -26,6 +26,15 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
currently this project is compiled with java 1.3 compatibility only, which
leads to a build failure. fixed by explicitly set java 1.7 compatibility
in pom.xml.
