### PR TITLE
Make OSIAM version configurable

### DIFF
--- a/addon-self-administration-plugin/src/main/java/org/osiam/addons/self_administration/plugin/impl/PluginImpl.java
+++ b/addon-self-administration-plugin/src/main/java/org/osiam/addons/self_administration/plugin/impl/PluginImpl.java
@@ -92,37 +92,43 @@ public class PluginImpl implements CallbackPlugin {
 
     private OsiamConnector getOsiamConnector() {
         if(connector == null){
-            connector = new OsiamConnector.Builder()
-                .withEndpoint(getOsiamEndpoint())
-                .setClientId(getClientId())
-                .setClientSecret(getClientSecret())
-                .build();
+            OsiamConnector.Builder builder = new OsiamConnector.Builder()
+                    .setClientId(getClientId())
+                    .setClientSecret(getClientSecret());
+
+            if (getOsiamVersion().startsWith("2")) {
+                builder.setEndpoint(getOsiamEndpoint());
+            } else {
+                builder.withEndpoint(getOsiamEndpoint());
+            }
+
+            connector = builder.build();
         }
 
         return connector;
     }
 
-    private String getProperty(String key, String defaultValue) {
-        return System.getProperty(key, defaultValue);
-    }
-
     private String getUserName() {
-        return getProperty("osiam.addon-self-administration.plugin.user.name", "admin");
+        return System.getProperty("osiam.addon-self-administration.plugin.user.name", "admin");
     }
 
     private String getUserPassword() {
-        return getProperty("osiam.addon-self-administration.plugin.user.password", "koala");
+        return System.getProperty("osiam.addon-self-administration.plugin.user.password", "koala");
     }
 
     private String getOsiamEndpoint() {
-        return getProperty("osiam.addon-self-administration.plugin.osiam.endpoint", "http://localhost:8080/osiam");
+        return System.getProperty("osiam.addon-self-administration.plugin.osiam.endpoint", "http://localhost:8080/osiam");
+    }
+
+    private String getOsiamVersion() {
+        return System.getProperty("osiam.addon-self-administration.plugin.osiam.version", "3");
     }
 
     private String getClientId() {
-        return getProperty("osiam.addon-self-administration.plugin.osiam.client.id", "example-client");
+        return System.getProperty("osiam.addon-self-administration.plugin.osiam.client.id", "example-client");
     }
 
     private String getClientSecret() {
-        return getProperty("osiam.addon-self-administration.plugin.osiam.client.secret", "secret");
+        return System.getProperty("osiam.addon-self-administration.plugin.osiam.client.secret", "secret");
     }
 }


### PR DESCRIPTION
Add property for version with default value of 3, so that the upcoming mainline version is supported by default. Check only the first character of the version for '2' to provide maximum flexibility. Use OSIAM 3 for any other version because it's the default. Inline the method `PluginImpl#getProperty`, because there's no need to wrap `System#getProperty`.